### PR TITLE
Always extract lamps

### DIFF
--- a/pipeline/core/core.py
+++ b/pipeline/core/core.py
@@ -2484,6 +2484,9 @@ class ReferenceData(object):
                 self.log.debug("In this case a compatible lamp will be "
                                "obtained from all the lamps obtained in the "
                                "data or present in the files.")
+                self.log.debug("Using the full set of comparison lamps "
+                               "for extraction.")
+                return comp_group
         return None
 
     def _recover_lines(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,4 +24,4 @@ edit_on_github = False
 github_project = soar-telescope/goodman
 # install_requires = astropy six gwcs scipy
 # version should be PEP440 compatible (http://www.python.org/dev/peps/pep-0440)
-version = 1.0.0
+version = 1.0.1


### PR DESCRIPTION
There is a method intended to filter available _comparison lamps_ against available _reference lamps_ in the library returning only those matching existing ones.

In the case that there was not possible to find a reference lamp it returned `None`.

Now it returns the same input. In other words, if it does not find any reference lamp it will extract all available lamps.
close #152 