### PR TITLE
fixed test for `get_last`. 

### DIFF
--- a/pipeline/tools/tests/test_version_checker.py
+++ b/pipeline/tools/tests/test_version_checker.py
@@ -13,7 +13,8 @@ class TestVersionChecker(unittest.TestCase):
     def test_get_last(self):
         try:
             v = version.get_last()
-            self.assertEqual(v, __version__)
+            self.assertRegex(v, '^(\*|\d+(\.\d+){0,2}(\.\*)?)$')
+            # self.assertEqual(v, __version__)
         except ConnectionRefusedError:
             pass
 


### PR DESCRIPTION
The last released version does not have to match the current version. Therefore tested against matching a regular expression since we just want to make sure that what `get_last` returns a valid version value not the last itself.
