### PR TITLE
adding authorized API Access for version check

### DIFF
--- a/pipeline/tools/check_version.py
+++ b/pipeline/tools/check_version.py
@@ -5,15 +5,21 @@ v1.0.0
 
 import logging
 import requests
+import os
 import re
 
 from distutils.version import LooseVersion
 
 logger = logging.getLogger(__name__)
 
-
-LATEST_URL = \
-    'https://api.github.com/repos/soar-telescope/goodman/releases/latest'
+try:
+    ACCESS_TOKEN = os.environ('GITHUB_ACCESS_TOKEN')
+    LATEST_URL = \
+        'https://api.github.com/repos/soar-telescope/goodman/releases/latest' \
+        '?access_token={:s}'.format(ACCESS_TOKEN)
+except KeyError:
+    LATEST_URL = \
+        'https://api.github.com/repos/soar-telescope/goodman/releases/latest'
 
 
 def get_last(url=LATEST_URL):


### PR DESCRIPTION
This PR implements authorized github API access to check for latest version.
This will only be available for official use. Other users will be limited to 60 access per hour as defined by github API.

The access token is stored in an environment variable